### PR TITLE
Add assertions to document assumptions

### DIFF
--- a/src/main/java/vatican/Parser.java
+++ b/src/main/java/vatican/Parser.java
@@ -24,6 +24,9 @@ public class Parser {
      * @throws VaticanException If the command is invalid or contains missing/incorrect parameters.
      */
     public static Command parse(String fullCommand) throws VaticanException {
+        // ASSERTION: The UI should never pass a null string to the parser
+        assert fullCommand != null : "Command string cannot be null";
+
         String[] parts = fullCommand.split(" ", 2);
         CommandType type = CommandType.fromString(parts[0]);
 

--- a/src/main/java/vatican/Vatican.java
+++ b/src/main/java/vatican/Vatican.java
@@ -27,6 +27,9 @@ public class Vatican {
      * @param filePath The path to the file where tasks are saved.
      */
     public Vatican(String filePath) {
+        // ASSERTION: Ensure the file path provided is valid
+        assert filePath != null && !filePath.isEmpty() : "File path cannot be null or empty";
+
         ui = new Ui();
         storage = new Storage(filePath);
         try {
@@ -41,6 +44,11 @@ public class Vatican {
      * Generates a response for the user's chat message.
      */
     public String getResponse(String input) {
+        // ASSERTION: Ensure critical components are initialized before processing input
+        assert ui != null : "UI should be initialized";
+        assert storage != null : "Storage should be initialized";
+        assert taskList != null : "TaskList should be initialized";
+
         try {
             java.io.ByteArrayOutputStream outContent = new java.io.ByteArrayOutputStream();
             java.io.PrintStream originalOut = System.out;

--- a/src/main/java/vatican/data/TaskList.java
+++ b/src/main/java/vatican/data/TaskList.java
@@ -23,6 +23,8 @@ public class TaskList {
      * @param loadedTasks The ArrayList of tasks loaded from storage.
      */
     public TaskList(ArrayList<Task> loadedTasks) {
+        // ASSERTION: Cannot initialize with a null list
+        assert loadedTasks != null : "Cannot initialize TaskList with null tasks";
         this.tasks = loadedTasks;
     }
 
@@ -31,6 +33,8 @@ public class TaskList {
      * @param task The task object to be added.
      */
     public void addTask(Task task) {
+        // ASSERTION: Ensure we don't add null tasks
+        assert task != null : "Cannot add a null task to the list";
         tasks.add(task);
     }
 
@@ -39,6 +43,8 @@ public class TaskList {
      * @param index The zero-based index of the task to remove.
      */
     public void deleteTask(int index) {
+        // ASSERTION: Index must be within valid bounds
+        assert index >= 0 && index < tasks.size() : "Delete index out of bounds";
         tasks.remove(index);
     }
 
@@ -47,6 +53,8 @@ public class TaskList {
      * @param index The zero-based index of the task to mark.
      */
     public void markTask(int index) {
+        // ASSERTION: Index must be within valid bounds
+        assert index >= 0 && index < tasks.size() : "Mark index out of bounds";
         Task task = tasks.get(index);
         task.markAsDone();
     }
@@ -56,6 +64,8 @@ public class TaskList {
      * @param index The zero-based index of the task to unmark.
      */
     public void unmarkTask(int index) {
+        // ASSERTION: Index must be within valid bounds
+        assert index >= 0 && index < tasks.size() : "Unmark index out of bounds";
         Task task = tasks.get(index);
         task.markAsNotDone();
     }
@@ -66,6 +76,8 @@ public class TaskList {
      * @return The Task object at the specified index.
      */
     public Task getTask(int index) {
+        // ASSERTION: Index must be within valid bounds
+        assert index >= 0 && index < tasks.size() : "Get task index out of bounds";
         return tasks.get(index);
     }
 
@@ -75,6 +87,7 @@ public class TaskList {
      * @return An ArrayList of matching tasks.
      */
     public ArrayList<Task> find(String keyword) {
+        assert keyword != null : "Search keyword cannot be null";
         ArrayList<Task> matchingTasks = new ArrayList<>();
         for (Task t : this.tasks) {
             if (t.getDescription().contains(keyword)) {


### PR DESCRIPTION
Vatican checks for invalid states using exceptions, but programmer errors and internal logic assumptions are currently undocumented.

Undocumented assumptions make the codebase fragile and difficult to debug when internal logic (like index handling) fails silently.

Add Java assertions to verify critical assumptions:
* Vatican: Ensure UI and Storage are initialised before use.
* TaskList: Validate index bounds for all retrieval operations.
* Parser: Ensure input strings are never null.