### PR TITLE
C-Help: Implement in-app guidance command

### DIFF
--- a/src/main/java/vatican/CommandType.java
+++ b/src/main/java/vatican/CommandType.java
@@ -4,7 +4,7 @@ package vatican;
  * Represents the various types of commands supported by the application.
  */
 public enum CommandType {
-    BYE, LIST, MARK, UNMARK, TODO, DEADLINE, EVENT, DELETE, FIND, UNKNOWN;
+    BYE, LIST, MARK, UNMARK, TODO, DEADLINE, EVENT, DELETE, FIND, HELP, UNKNOWN;
 
     /**
      * Returns the CommandType corresponding to the given string.

--- a/src/main/java/vatican/Parser.java
+++ b/src/main/java/vatican/Parser.java
@@ -5,6 +5,7 @@ import vatican.command.Command;
 import vatican.command.DeleteCommand;
 import vatican.command.ExitCommand;
 import vatican.command.FindCommand;
+import vatican.command.HelpCommand;
 import vatican.command.ListCommand;
 import vatican.command.MarkCommand;
 import vatican.task.Deadline;
@@ -48,6 +49,8 @@ public class Parser {
             return prepareDeadline(parts);
         case EVENT:
             return prepareEvent(parts);
+        case HELP:
+            return new HelpCommand();
         default:
             throw new VaticanException("I don't know what that means. Nize that.");
         }

--- a/src/main/java/vatican/command/HelpCommand.java
+++ b/src/main/java/vatican/command/HelpCommand.java
@@ -1,0 +1,27 @@
+package vatican.command;
+
+import vatican.data.Storage;
+import vatican.data.TaskList;
+import vatican.ui.Ui;
+
+/**
+ * Provides guidance on how to use the Vatican bot.
+ */
+public class HelpCommand extends Command {
+    @Override
+    public void execute(TaskList tasks, Ui ui, Storage storage) {
+        String helpMessage = "Here's how you use Vatican, dun know:\n\n"
+                + "1. todo [desc] - Add a simple mission.\n"
+                + "2. deadline [desc] /by [date] - Add a mission with a cutoff.\n"
+                + "3. event [desc] /from [time] /to [time] - Add a timed link-up.\n"
+                + "4. list - See all your current blessings.\n"
+                + "5. mark [index] - Check off a task (Green style).\n"
+                + "6. unmark [index] - Re-open a task.\n"
+                + "7. delete [index] - Clear a task, styll (Orange style).\n"
+                + "8. find [keyword] - Search for specific business.\n"
+                + "9. help - See this menu again.\n"
+                + "10. bye - Wallahi, I'll be outta there crodie.";
+
+        ui.showToUser(helpMessage);
+    }
+}


### PR DESCRIPTION
Users currently have no way to view the available command syntax within the application.

Without a help command, users must rely on memory or external documentation to know the specific triggers like '/by' or '/from /to'.

Let's implement a HelpCommand and register the 'help' keyword:
* Add HELP to CommandType enum.
* Implement HelpCommand to display a formatted list of all command syntaxes.
* Update Parser to route 'help' input to the new command.

This improves user experience by providing immediate assistance and reduces the learning curve for new users.